### PR TITLE
tests: fix order of expected/actual values passed to asserts

### DIFF
--- a/.changeset/many-waves-cry.md
+++ b/.changeset/many-waves-cry.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+tests: fix order of expected/actual values passed to asserts.

--- a/tests/unit/BlockAttributesObjectTest.php
+++ b/tests/unit/BlockAttributesObjectTest.php
@@ -60,8 +60,8 @@ final class BlockAttributesObjectTest extends PluginTestCase {
 		// Verify that the ID of the first post matches the one we just created.
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 		// There should be only 1 block
-		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
+		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
 		// There should be a style attribute that matches the json for the content of the attribute
-		$this->assertEquals( $node['editorBlocks'][0]['attributes']['style'], '{"color":{"background":"#a62929"}}' );
+		$this->assertEquals( '{"color":{"background":"#a62929"}}', $node['editorBlocks'][0]['attributes']['style'] );
 	}
 }

--- a/tests/unit/BlockQueriesTest.php
+++ b/tests/unit/BlockQueriesTest.php
@@ -67,8 +67,8 @@ final class BlockQueriesTest extends PluginTestCase {
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 
 		// There should be only one block using that query when not using flat: true
-		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
-		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/columns' );
+		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
+		$this->assertEquals( 'core/columns', $node['editorBlocks'][0]['name'] );
 	}
 
 	public function test_retrieve_flatten_editor_blocks() {
@@ -93,21 +93,21 @@ final class BlockQueriesTest extends PluginTestCase {
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 
 		// There should more than one block using that query when using flat: true
-		$this->assertEquals( count( $node['editorBlocks'] ), 5 );
+		$this->assertEquals( 5, count( $node['editorBlocks'] ) );
 
-		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/columns' );
+		$this->assertEquals( 'core/columns', $node['editorBlocks'][0]['name'] );
 		$this->assertNull( $node['editorBlocks'][0]['parentClientId'] );
 
-		$this->assertEquals( $node['editorBlocks'][1]['name'], 'core/column' );
+		$this->assertEquals( 'core/column', $node['editorBlocks'][1]['name'] );
 		$this->assertNotNull( $node['editorBlocks'][1]['parentClientId'] );
 
-		$this->assertEquals( $node['editorBlocks'][2]['name'], 'core/paragraph' );
+		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][2]['name'] );
 		$this->assertNotNull( $node['editorBlocks'][2]['parentClientId'] );
 
-		$this->assertEquals( $node['editorBlocks'][3]['name'], 'core/column' );
+		$this->assertEquals( 'core/column', $node['editorBlocks'][3]['name'] );
 		$this->assertNotNull( $node['editorBlocks'][3]['parentClientId'] );
 
-		$this->assertEquals( $node['editorBlocks'][4]['name'], 'core/paragraph' );
+		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][4]['name'] );
 		$this->assertNotNull( $node['editorBlocks'][4]['parentClientId'] );
 	}
 }

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -62,7 +62,7 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 		$this->instance::register( $block );
 
 		// Verify BlockWithSupportsAnchor fields registration
-		$query    = '
+		$query = '
 		query BlockWithSupportsAnchorMeta {
 			__type(name: "BlockWithSupportsAnchor") {
 				fields {
@@ -92,7 +92,7 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 			],
 		];
 		$this->assertArrayHasKey( 'data', $actual, json_encode( $actual ) );
-		$this->assertEquals( $actual['data']['__type']['fields'], $expected['fields'] );
+		$this->assertEquals( $expected['fields'], $actual['data']['__type']['fields'] );
 		$this->assertContains( $expected['possibleTypes'][0], $actual['data']['__type']['possibleTypes'] );
 		$this->assertContains( $expected['possibleTypes'][1], $actual['data']['__type']['possibleTypes'] );
 	}
@@ -121,17 +121,17 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 		$actual = graphql( [ 'query' => $query ] );
 		$node   = $actual['data']['posts']['nodes'][0];
 
-		$this->assertEquals( count( $node['editorBlocks'] ), 4 );
-		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/paragraph' );
-		$this->assertEquals( $node['editorBlocks'][0]['anchor'], 'example' );
+		$this->assertEquals( 4, count( $node['editorBlocks'] ) );
+		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][0]['name'] );
+		$this->assertEquals( 'example', $node['editorBlocks'][0]['anchor'] );
 
-		$this->assertEquals( $node['editorBlocks'][1]['name'], 'core/paragraph' );
+		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][1]['name'] );
 		$this->assertNull( $node['editorBlocks'][1]['anchor'] );
 
-		$this->assertEquals( $node['editorBlocks'][2]['name'], 'core/group' );
+		$this->assertEquals( 'core/group', $node['editorBlocks'][2]['name'] );
 		$this->assertNull( $node['editorBlocks'][2]['anchor'] );
 
-		$this->assertEquals( $node['editorBlocks'][3]['name'], 'core/paragraph' );
-		$this->assertEquals( $node['editorBlocks'][3]['anchor'], 'example-inner' );
+		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][3]['name'] );
+		$this->assertEquals( 'example-inner', $node['editorBlocks'][3]['anchor'] );
 	}
 }

--- a/tests/unit/CoreImageTest.php
+++ b/tests/unit/CoreImageTest.php
@@ -65,11 +65,11 @@ final class CoreImageTest extends PluginTestCase {
 		$node   = $actual['data']['posts']['nodes'][0];
 
 		$this->assertEquals(
-			$node['editorBlocks'][0]['mediaDetails'],
 			[
 				'width'  => 50,
 				'height' => 50,
-			]
+			],
+			$node['editorBlocks'][0]['mediaDetails']
 		);
 	}
 
@@ -111,11 +111,10 @@ final class CoreImageTest extends PluginTestCase {
 		// Verify that the ID of the first post matches the one we just created.
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 		// There should be only one block using that query when not using flat: true
-		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
-		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/image' );
+		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
+		$this->assertEquals( 'core/image', $node['editorBlocks'][0]['name'] );
 
 		$this->assertEquals(
-			$node['editorBlocks'][0]['attributes'],
 			[
 				'width'           => '500',
 				'height'          => 500.0,
@@ -130,7 +129,8 @@ final class CoreImageTest extends PluginTestCase {
 				'align'           => null,
 				'caption'         => '',
 				'cssClassName'    => 'wp-block-image size-full is-resized',
-			]
+			],
+			$node['editorBlocks'][0]['attributes']
 		);
 	}
 }

--- a/tests/unit/CoreTableTest.php
+++ b/tests/unit/CoreTableTest.php
@@ -41,7 +41,7 @@ final class CoreTableTest extends PluginTestCase {
 
 	public function test_retrieve_core_table_attribute_fields() {
 		$this->markTestSkipped( 'must be revisited since the test is failing on the CI for an unknown reason' );
-		$query  = '
+		$query = '
 			fragment CoreTableBlockFragment on CoreTable {
 				attributes {
 					caption
@@ -64,18 +64,18 @@ final class CoreTableTest extends PluginTestCase {
 
 		$actual = graphql( [ 'query' => $query ] );
 
-		$node   = $actual['data']['posts']['nodes'][0];
+		$node = $actual['data']['posts']['nodes'][0];
 
-		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/table' );
+		$this->assertEquals( 'core/table', $node['editorBlocks'][0]['name'] );
 		// There should be only one block using that query when not using flat: true
-		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
+		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
 		$this->assertEquals(
-			$node['editorBlocks'][0]['attributes'],
 			[
 				'caption' => 'Caption',
 				'align'   => null,
 				'anchor'  => null,
-			]
+			],
+			$node['editorBlocks'][0]['attributes']
 		);
 	}
 }

--- a/tests/unit/CoreVideoTest.php
+++ b/tests/unit/CoreVideoTest.php
@@ -76,11 +76,10 @@ final class CoreVideoTest extends PluginTestCase {
 		// Verify that the ID of the first post matches the one we just created.
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 		// There should be only one block using that query when not using flat: true
-		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
-		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/video' );
+		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
+		$this->assertEquals( 'core/video', $node['editorBlocks'][0]['name'] );
 
 		$this->assertEquals(
-			$node['editorBlocks'][0]['attributes'],
 			[
 				'align'       => null,
 				'anchor'      => null,
@@ -95,7 +94,8 @@ final class CoreVideoTest extends PluginTestCase {
 				'loop'        => true,
 				'poster'      => 'http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg',
 				'id'          => 1636.0,
-			]
+			],
+			$node['editorBlocks'][0]['attributes']
 		);
 	}
 }

--- a/tests/unit/DOMHelpersTest.php
+++ b/tests/unit/DOMHelpersTest.php
@@ -21,16 +21,16 @@ final class DOMHelpersTest extends PluginTestCase {
 		// $html
 		$this->assertNull( DOMHelpers::parse_attribute( '', $no_existent_selector, $data_attribute ) );
 		$this->assertNull( DOMHelpers::parse_attribute( $html, $no_existent_selector, $data_attribute ) );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $no_existent_selector, $data_attribute, 'Bar' ), 'Bar' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $id_selector, $data_attribute ), 'foo-data' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $id_selector, $class_attribute ), 'foo-class' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $id_selector, $id_attribute ), 'foo-id' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $class_selector, $data_attribute ), 'foo-data' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $class_selector, $class_attribute ), 'foo-class' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $class_selector, $id_attribute ), 'foo-id' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $element_selector, $data_attribute ), 'foo-data' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $element_selector, $class_attribute ), 'foo-class' );
-		$this->assertEquals( DOMHelpers::parse_attribute( $html, $element_selector, $id_attribute ), 'foo-id' );
+		$this->assertEquals( 'Bar', DOMHelpers::parse_attribute( $html, $no_existent_selector, $data_attribute, 'Bar' ) );
+		$this->assertEquals( 'foo-data', DOMHelpers::parse_attribute( $html, $id_selector, $data_attribute ) );
+		$this->assertEquals( 'foo-class', DOMHelpers::parse_attribute( $html, $id_selector, $class_attribute ) );
+		$this->assertEquals( 'foo-id', DOMHelpers::parse_attribute( $html, $id_selector, $id_attribute ) );
+		$this->assertEquals( 'foo-data', DOMHelpers::parse_attribute( $html, $class_selector, $data_attribute ) );
+		$this->assertEquals( 'foo-class', DOMHelpers::parse_attribute( $html, $class_selector, $class_attribute ) );
+		$this->assertEquals( 'foo-id', DOMHelpers::parse_attribute( $html, $class_selector, $id_attribute ) );
+		$this->assertEquals( 'foo-data', DOMHelpers::parse_attribute( $html, $element_selector, $data_attribute ) );
+		$this->assertEquals( 'foo-class', DOMHelpers::parse_attribute( $html, $element_selector, $class_attribute ) );
+		$this->assertEquals( 'foo-id', DOMHelpers::parse_attribute( $html, $element_selector, $id_attribute ) );
 
 		// $html2
 		$this->assertEquals( 'center', DOMHelpers::parse_attribute( $html2, '*', 'data-align' ) );
@@ -52,10 +52,10 @@ final class DOMHelpersTest extends PluginTestCase {
 
 		$this->assertNull( DOMHelpers::parse_html( '', $no_existent_selector ) );
 		$this->assertEmpty( DOMHelpers::parse_html( $html, $no_existent_selector ) );
-		$this->assertEquals( DOMHelpers::parse_html( $html, $no_existent_selector, 'Bar' ), 'Bar' );
-		$this->assertEquals( DOMHelpers::parse_html( $html, $id_selector ), '<span>Bar</span>' );
-		$this->assertEquals( DOMHelpers::parse_html( $html, $class_selector ), '<span>Bar</span>' );
-		$this->assertEquals( DOMHelpers::parse_html( $html, $element_selector ), '<span>Bar</span>' );
+		$this->assertEquals( 'Bar', DOMHelpers::parse_html( $html, $no_existent_selector, 'Bar' ) );
+		$this->assertEquals( '<span>Bar</span>', DOMHelpers::parse_html( $html, $id_selector ) );
+		$this->assertEquals( '<span>Bar</span>', DOMHelpers::parse_html( $html, $class_selector ) );
+		$this->assertEquals( '<span>Bar</span>', DOMHelpers::parse_html( $html, $element_selector ) );
 	}
 
 	public function testGetElementsFromHTML(): void {
@@ -64,7 +64,7 @@ final class DOMHelpersTest extends PluginTestCase {
 		$no_existent_selector = 'span';
 
 		$this->assertNull( DOMHelpers::get_elements_from_html( '', $no_existent_selector ) );
-		$this->assertEquals( DOMHelpers::get_elements_from_html( $html, $element_selector ), '<p>First paragraph</p><p>Second paragraph</p>' );
+		$this->assertEquals( '<p>First paragraph</p><p>Second paragraph</p>', DOMHelpers::get_elements_from_html( $html, $element_selector ) );
 		$this->assertEmpty( DOMHelpers::get_elements_from_html( $html, $no_existent_selector ) );
 	}
 
@@ -78,10 +78,10 @@ final class DOMHelpersTest extends PluginTestCase {
 
 		// getTextFromSelector should get all text (even descendents) according to "textContent"
 		// https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
-		$this->assertEquals( DOMHelpers::getTextFromSelector( $html, $blockquote_element ), 'First paragraphMy divSecond paragraph' );
+		$this->assertEquals( 'First paragraphMy divSecond paragraph', DOMHelpers::getTextFromSelector( $html, $blockquote_element ) );
 
-		$this->assertEquals( DOMHelpers::getTextFromSelector( $html, $p_element ), 'First paragraph' );
-		$this->assertEquals( DOMHelpers::getTextFromSelector( $html, $div_element ), 'My div' );
+		$this->assertEquals( 'First paragraph', DOMHelpers::getTextFromSelector( $html, $p_element ) );
+		$this->assertEquals( 'My div', DOMHelpers::getTextFromSelector( $html, $div_element ) );
 		$this->assertEmpty( DOMHelpers::get_elements_from_html( $html, $no_existent_selector ) );
 	}
 }

--- a/tests/unit/EditorBlockInterfaceTest.php
+++ b/tests/unit/EditorBlockInterfaceTest.php
@@ -66,7 +66,7 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 			],
 		];
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
-		$this->assertEquals( $response['data']['__type'], $expected );
+		$this->assertEquals( $expected, $response['data']['__type'] );
 
 		$queryContentBlockMeta = '
 		query ContentBlockMeta {
@@ -107,6 +107,6 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 		);
 		sort( $actual );
 		sort( $expected );
-		$this->assertEquals( $actual, $expected );
+		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/unit/PostTypeBlockInterfaceTest.php
+++ b/tests/unit/PostTypeBlockInterfaceTest.php
@@ -57,7 +57,7 @@ final class PostTypeBlockInterfaceTest extends PluginTestCase {
 			],
 		];
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
-		$this->assertEquals( $response['data']['__type'], $expected );
+		$this->assertEquals( $expected, $response['data']['__type'] );
 
 		// Verify PostEditorBlock fields registration
 		$queryContentBlockMeta = '
@@ -99,6 +99,6 @@ final class PostTypeBlockInterfaceTest extends PluginTestCase {
 		);
 		sort( $actual );
 		sort( $expected );
-		$this->assertEquals( $actual, $expected );
+		$this->assertEquals( $expected, $actual );
 	}
 }

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -185,7 +185,7 @@ final class RegistryTestCase extends PluginTestCase {
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
 		$this->assertNotEmpty( $response['data']['__type']['interfaces'] );
 		$this->assertTrue( in_array( $contains_interface, $response['data']['__type']['interfaces'] ) );
-		$this->assertEquals( array_intersect_key( $contains_detail, $response['data']['__type'] ), $contains_detail );
+		$this->assertEquals( $contains_detail, array_intersect_key( $contains_detail, $response['data']['__type'] ) );
 		$this->assertEquals( $contains_possible_types, $response['data']['__type']['possibleTypes'] );
 
 		// Verify NodeWithPostEditorBlocks meta
@@ -209,6 +209,6 @@ final class RegistryTestCase extends PluginTestCase {
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
 		$this->assertNotEmpty( $response['data']['__type']['interfaces'] );
 		$this->assertTrue( in_array( $contains_interface, $response['data']['__type']['interfaces'] ) );
-		$this->assertEquals( array_intersect_key( $contains_detail, $response['data']['__type'] ), $contains_detail );
+		$this->assertEquals( $contains_detail, array_intersect_key( $contains_detail, $response['data']['__type'] ) );
 	}
 }


### PR DESCRIPTION
Tracking https://github.com/wpengine/wp-graphql-content-blocks/pull/287