### PR TITLE
tests : Add tests for `CoreSeparator` block.

### DIFF
--- a/.changeset/odd-hounds-sing.md
+++ b/.changeset/odd-hounds-sing.md
@@ -2,4 +2,4 @@
 "@wpengine/wp-graphql-content-blocks": patch
 ---
 
-tests : Core Separator block fields and attributes.
+tests : Add tests for `CoreSeparator` block.

--- a/.changeset/odd-hounds-sing.md
+++ b/.changeset/odd-hounds-sing.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+tests : Core Separator block fields and attributes.

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -71,6 +71,16 @@ final class CoreSeparatorTest extends PluginTestCase {
 		';
 	}
 
+	/**
+	 * Test the retrieval of core/separator block fields and attributes.
+	 *
+	 * This test verifies that the block attributes for the core/separator block are
+	 * properly returned via the GraphQL query. The test ensures that the block content,
+	 * client ID, block name, and rendered HTML are correctly returned and that the attributes
+	 * (such as align, className, gradient, opacity, style and lock) match the expected values.
+	 *
+	 * @return void
+	 */
 	public function test_core_separator_fields_and_attributes() {
 		$block_content = '
 		<!-- wp:separator {"lock":{"move":true,"remove":true},"align":"wide","className":"is-style-dots","style":{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}} -->
@@ -123,7 +133,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 				'backgroundColor' => null,
 				'className'       => 'is-style-dots',
 				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
-				'gradient'        => null, // @todo: getting null returned here, but should be the gradient value.
+				'gradient'        => null, // @todo: Getting null, but should be some valid gradient value.
 				'opacity'         => 'alpha-channel',
 				'style'           => '{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}',
 				'lock'            => '{"move":true,"remove":true}',
@@ -132,7 +142,17 @@ final class CoreSeparatorTest extends PluginTestCase {
 		);
 	}
 
-	public function test_core_separator_untested_attributes() {
+	/**
+	 * Test the retrieval of core/separator block fields and attributes.
+	 *
+	 * This test verifies that the block attributes for the core/separator block are
+	 * properly returned via the GraphQL query. The test ensures that the block content,
+	 * client ID, block name, and rendered HTML are correctly returned and that the attributes
+	 * (such as anchor, backgroundColor and cssClassName) match the expected values.
+	 *
+	 * @return void
+	 */
+	public function test_core_separator_attributes() {
 		$block_content = '
 			<!-- wp:separator {"backgroundColor":"accent-4"}  -->
 			<hr class="wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background" id="test-anchor"/>

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -83,9 +83,9 @@ final class CoreSeparatorTest extends PluginTestCase {
 	 */
 	public function test_core_separator_fields_and_attributes() {
 		$block_content = '
-		<!-- wp:separator {"lock":{"move":true,"remove":true},"align":"wide","className":"is-style-dots","style":{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}} -->
-		<hr class="wp-block-separator alignwide has-alpha-channel-opacity"/>
-		<!-- /wp:separator -->
+			<!-- wp:separator {"lock":{"move":true,"remove":true},"align":"wide","className":"is-style-dots","style":{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}} -->
+			<hr class="wp-block-separator alignwide has-alpha-channel-opacity"/>
+			<!-- /wp:separator -->
 		';
 
 		// Set post content.
@@ -106,11 +106,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
-
-		// Verify that the ID of the first post matches the one we just created.
 		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
-
-		// There should be only one block using that query when not using flat: true
 		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ) );
 
 		$block = $actual['data']['post']['editorBlocks'][0];
@@ -125,6 +121,14 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
+		$style = wp_json_encode(
+			[
+				'color' => [
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)',
+				],
+			]
+		);
+
 		// Verify the attributes.
 		$this->assertEquals(
 			[
@@ -135,8 +139,13 @@ final class CoreSeparatorTest extends PluginTestCase {
 				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
 				'gradient'        => null, // @todo: Getting null, but should be some valid gradient value.
 				'opacity'         => 'alpha-channel',
-				'style'           => '{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}',
-				'lock'            => '{"move":true,"remove":true}',
+				'style'           => $style,
+				'lock'            => wp_json_encode(
+					[
+						'move'   => true,
+						'remove' => true,
+					]
+				),
 			],
 			$block['attributes'],
 		);
@@ -177,11 +186,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
-
-		// Verify that the ID of the first post matches the one we just created.
 		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
-
-		// There should be only one block using that query when not using flat: true
 		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ) );
 		$this->assertEquals( 'core/separator', $actual['data']['post']['editorBlocks'][0]['name'], 'The block name should be core/separator' );
 

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+final class CoreSeparatorTest extends PluginTestCase {
+	/**
+	 * The ID of the post created for the test.
+	 *
+	 * @var int
+	 */
+	public $post_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_id = wp_insert_post(
+			[
+				'post_title'   => 'Post with Separator',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			]
+		);
+
+		\WPGraphQL::clear_schema();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_delete_post( $this->post_id, true );
+
+		\WPGraphQL::clear_schema();
+	}
+
+	public function query(): string {
+		return '
+            fragment CoreSeparatorBlockFragment on CoreSeparator {
+                attributes {
+                    align
+                    anchor
+                    backgroundColor
+                    className
+                    cssClassName
+                    gradient
+                    opacity
+                    style
+                }
+            }
+
+            query Post( $id: ID! ) {
+                post(id: $id, idType: DATABASE_ID) {
+                    databaseId
+                    editorBlocks {
+                        apiVersion
+                        blockEditorCategoryName
+                        clientId
+                        cssClassNames
+                        innerBlocks {
+                            name
+                        }
+                        isDynamic
+                        name
+                        parentClientId
+                        renderedHtml
+                        ...CoreSeparatorBlockFragment
+                    }
+                }
+            }
+        ';
+	}
+
+	public function test_retrieve_core_separator_attributes() {
+		$block_content = '
+        <!-- wp:separator {"align":"wide"} -->
+        <hr class="wp-block-separator alignwide has-alpha-channel-opacity"/>
+        <!-- /wp:separator -->
+        ';
+
+		// Set post content.
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$query     = $this->query();
+		$variables = [
+			'id' => $this->post_id,
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
+		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
+		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
+
+		// Verify that the ID of the first post matches the one we just created.
+		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
+
+		// There should be only one block using that query when not using flat: true
+		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ) );
+		$this->assertEquals( 'core/separator', $actual['data']['post']['editorBlocks'][0]['name'], 'The block name should be core/separator' );
+
+		// Verify the attributes.
+		$this->assertEquals(
+			[
+				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
+				'align'           => 'wide',
+				'anchor'          => null,
+				'backgroundColor' => null,
+				'className'       => null,
+				'gradient'        => null,
+				'opacity'         => 'alpha-channel',
+				'style'           => null,
+			],
+			$actual['data']['post']['editorBlocks'][0]['attributes'],
+		);
+	}
+
+	public function test_retrieve_core_separator_attributes_two() {
+		$block_content = '
+            <!-- wp:separator -->
+            <hr class="wp-block-separator has-alpha-channel-opacity"/>
+            <!-- /wp:separator -->
+        ';
+
+		// Set post content.
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$query     = $this->query();
+		$variables = [
+			'id' => $this->post_id,
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
+		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
+		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
+
+		// Verify that the ID of the first post matches the one we just created.
+		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
+
+		// There should be only one block using that query when not using flat: true
+		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ) );
+		$this->assertEquals( 'core/separator', $actual['data']['post']['editorBlocks'][0]['name'], 'The block name should be core/separator' );
+
+		// Verify the attributes.
+		$this->assertEquals(
+			[
+				'cssClassName'    => 'wp-block-separator has-alpha-channel-opacity',
+				'align'           => null,
+				'anchor'          => null,
+				'backgroundColor' => null,
+				'className'       => null,
+				'gradient'        => null,
+				'opacity'         => 'alpha-channel',
+				'style'           => null,
+			],
+			$actual['data']['post']['editorBlocks'][0]['attributes'],
+		);
+	}
+}

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -73,15 +73,8 @@ final class CoreSeparatorTest extends PluginTestCase {
 
 	/**
 	 * Test the retrieval of core/separator block fields and attributes.
-	 *
-	 * This test verifies that the block attributes for the core/separator block are
-	 * properly returned via the GraphQL query. The test ensures that the block content,
-	 * client ID, block name, and rendered HTML are correctly returned and that the attributes
-	 * (such as align, className, gradient, opacity, style and lock) match the expected values.
-	 *
-	 * @return void
 	 */
-	public function test_core_separator_fields_and_attributes() {
+	public function test_retrieve_core_separator_attribute_fields(): void {
 		$block_content = '
 			<!-- wp:separator {"lock":{"move":true,"remove":true},"align":"wide","className":"is-style-dots","style":{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}} -->
 			<hr class="wp-block-separator alignwide has-alpha-channel-opacity"/>
@@ -121,14 +114,6 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
-		$style = wp_json_encode(
-			[
-				'color' => [
-					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)',
-				],
-			]
-		);
-
 		// Verify the attributes.
 		$this->assertEquals(
 			[
@@ -137,9 +122,15 @@ final class CoreSeparatorTest extends PluginTestCase {
 				'backgroundColor' => null,
 				'className'       => 'is-style-dots',
 				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
-				'gradient'        => null, // @todo: Getting null, but should be some valid gradient value.
+				'gradient'        => null, // @todo: Getting null, but should be some valid gradient value!!
 				'opacity'         => 'alpha-channel',
-				'style'           => $style,
+				'style'           => wp_json_encode(
+					[
+						'color' => [
+							'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)',
+						],
+					]
+				),
 				'lock'            => wp_json_encode(
 					[
 						'move'   => true,
@@ -152,16 +143,11 @@ final class CoreSeparatorTest extends PluginTestCase {
 	}
 
 	/**
-	 * Test the retrieval of core/separator block fields and attributes.
+	 * Tests additional CoreSeparatorAttributes values.
 	 *
-	 * This test verifies that the block attributes for the core/separator block are
-	 * properly returned via the GraphQL query. The test ensures that the block content,
-	 * client ID, block name, and rendered HTML are correctly returned and that the attributes
-	 * (such as anchor, backgroundColor and cssClassName) match the expected values.
-	 *
-	 * @return void
+	 * Covers: `anchor`, `backgroundColor`, and `gradient`.
 	 */
-	public function test_core_separator_attributes() {
+	public function test_retrieve_core_separator_attributes(): void {
 		$block_content = '
 			<!-- wp:separator {"backgroundColor":"accent-4"}  -->
 			<hr class="wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background" id="test-anchor"/>
@@ -194,8 +180,8 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertEquals(
 			[
 				'align'           => null,
-				'anchor'          => 'test-anchor',
-				'backgroundColor' => 'accent-4',
+				'anchor'          => 'test-anchor', // Previously untested.
+				'backgroundColor' => 'accent-4', // Previously untested.
 				'className'       => null,
 				'cssClassName'    => 'wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background',
 				'gradient'        => null,

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -122,7 +122,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 				'backgroundColor' => null,
 				'className'       => 'is-style-dots',
 				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
-				'gradient'        => null, // @todo: Getting null, but should be some valid gradient value!!
+				'gradient'        => null,
 				'opacity'         => 'alpha-channel',
 				'style'           => wp_json_encode(
 					[
@@ -149,7 +149,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 	 */
 	public function test_retrieve_core_separator_attributes(): void {
 		$block_content = '
-			<!-- wp:separator {"backgroundColor":"accent-4"}  -->
+			<!-- wp:separator {"gradient":"gradient-10","backgroundColor":"accent-4"}  -->
 			<hr class="wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background" id="test-anchor"/>
 			<!-- /wp:separator -->
 		';
@@ -184,7 +184,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 				'backgroundColor' => 'accent-4', // Previously untested.
 				'className'       => null,
 				'cssClassName'    => 'wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background',
-				'gradient'        => null,
+				'gradient'        => 'gradient-10', // Previously untested.
 				'opacity'         => 'alpha-channel',
 				'style'           => null,
 				'lock'            => null,

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -34,47 +34,49 @@ final class CoreSeparatorTest extends PluginTestCase {
 
 	public function query(): string {
 		return '
-            fragment CoreSeparatorBlockFragment on CoreSeparator {
-                attributes {
-                    align
-                    anchor
-                    backgroundColor
-                    className
-                    cssClassName
-                    gradient
-                    opacity
-                    style
-                }
-            }
+			fragment CoreSeparatorBlockFragment on CoreSeparator {
+				attributes {
+					align
+					anchor
+					backgroundColor
+					className
+					cssClassName
+					gradient
+					lock
+					# metadata
+					opacity
+					style
+				}
+			}
 
-            query Post( $id: ID! ) {
-                post(id: $id, idType: DATABASE_ID) {
-                    databaseId
-                    editorBlocks {
-                        apiVersion
-                        blockEditorCategoryName
-                        clientId
-                        cssClassNames
-                        innerBlocks {
-                            name
-                        }
-                        isDynamic
-                        name
-                        parentClientId
-                        renderedHtml
-                        ...CoreSeparatorBlockFragment
-                    }
-                }
-            }
-        ';
+			query Post( $id: ID! ) {
+				post(id: $id, idType: DATABASE_ID) {
+					databaseId
+					editorBlocks {
+						apiVersion
+						blockEditorCategoryName
+						clientId
+						cssClassNames
+						innerBlocks {
+							name
+						}
+						isDynamic
+						name
+						parentClientId
+						renderedHtml
+						...CoreSeparatorBlockFragment
+					}
+				}
+			}
+		';
 	}
 
-	public function test_retrieve_core_separator_attributes() {
+	public function test_core_separator_fields_and_attributes() {
 		$block_content = '
-        <!-- wp:separator {"align":"wide"} -->
-        <hr class="wp-block-separator alignwide has-alpha-channel-opacity"/>
-        <!-- /wp:separator -->
-        ';
+		<!-- wp:separator {"lock":{"move":true,"remove":true},"align":"wide","className":"is-style-dots","style":{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}} -->
+		<hr class="wp-block-separator alignwide has-alpha-channel-opacity"/>
+		<!-- /wp:separator -->
+		';
 
 		// Set post content.
 		wp_update_post(
@@ -100,30 +102,42 @@ final class CoreSeparatorTest extends PluginTestCase {
 
 		// There should be only one block using that query when not using flat: true
 		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ) );
-		$this->assertEquals( 'core/separator', $actual['data']['post']['editorBlocks'][0]['name'], 'The block name should be core/separator' );
+
+		$block = $actual['data']['post']['editorBlocks'][0];
+
+		// Verify the block data.
+		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
+		$this->assertEquals( 'design', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be text' );
+		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
+		$this->assertNotEmpty( $block['cssClassNames'], 'There should be cssClassNames' );
+		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
+		$this->assertEquals( 'core/separator', $block['name'], 'The block name should be core/separator' );
+		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
 		// Verify the attributes.
 		$this->assertEquals(
 			[
-				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
 				'align'           => 'wide',
 				'anchor'          => null,
 				'backgroundColor' => null,
-				'className'       => null,
-				'gradient'        => null,
+				'className'       => 'is-style-dots',
+				'cssClassName'    => 'wp-block-separator alignwide has-alpha-channel-opacity',
+				'gradient'        => null, // @todo: getting null returned here, but should be the gradient value.
 				'opacity'         => 'alpha-channel',
-				'style'           => null,
+				'style'           => '{"color":{"gradient":"linear-gradient(135deg,rgb(6,147,227) 1%,rgb(155,81,224) 100%)"}}',
+				'lock'            => '{"move":true,"remove":true}',
 			],
-			$actual['data']['post']['editorBlocks'][0]['attributes'],
+			$block['attributes'],
 		);
 	}
 
-	public function test_retrieve_core_separator_attributes_two() {
+	public function test_core_separator_untested_attributes() {
 		$block_content = '
-            <!-- wp:separator -->
-            <hr class="wp-block-separator has-alpha-channel-opacity"/>
-            <!-- /wp:separator -->
-        ';
+			<!-- wp:separator {"backgroundColor":"accent-4"}  -->
+			<hr class="wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background" id="test-anchor"/>
+			<!-- /wp:separator -->
+		';
 
 		// Set post content.
 		wp_update_post(
@@ -154,14 +168,15 @@ final class CoreSeparatorTest extends PluginTestCase {
 		// Verify the attributes.
 		$this->assertEquals(
 			[
-				'cssClassName'    => 'wp-block-separator has-alpha-channel-opacity',
 				'align'           => null,
-				'anchor'          => null,
-				'backgroundColor' => null,
+				'anchor'          => 'test-anchor',
+				'backgroundColor' => 'accent-4',
 				'className'       => null,
+				'cssClassName'    => 'wp-block-separator has-text-color has-accent-4-color has-alpha-channel-opacity has-accent-4-background-color has-background',
 				'gradient'        => null,
 				'opacity'         => 'alpha-channel',
 				'style'           => null,
+				'lock'            => null,
 			],
 			$actual['data']['post']['editorBlocks'][0]['attributes'],
 		);


### PR DESCRIPTION
Tracking https://github.com/wpengine/wp-graphql-content-blocks/pull/294

---

## What:
This PR backfills tests for the `CoreSeparator` block and its attributes.

## Tested attributes:

- align
- anchor
- backgroundColor
- className
- cssClassName
- gradient
- lock
- opacity
- style

## Untested fields:

- `CoreSeparatorAttributes.metadata` - @todo

## Exposed issues:

NA