### PR TITLE
Feat : backporting `populate_template_part_inner_blocks`

### DIFF
--- a/.changeset/silver-cups-explode.md
+++ b/.changeset/silver-cups-explode.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving Template Part blocks

--- a/.changeset/tiny-news-warn.md
+++ b/.changeset/tiny-news-warn.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving Block Patterns

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -151,6 +151,8 @@ final class ContentBlocksResolver {
 
 		$block = self::populate_reusable_blocks( $block );
 
+		$block = self::populate_pattern_inner_blocks( $block );
+
 		// Prepare innerBlocks.
 		if ( ! empty( $block['innerBlocks'] ) ) {
 			$block['innerBlocks'] = self::handle_do_blocks( $block['innerBlocks'] );
@@ -206,6 +208,32 @@ final class ContentBlocksResolver {
 		}
 
 		return array_merge( ...$parsed_blocks );
+	}
+
+	/**
+	 * Populates the pattern innerBlocks with the blocks from the pattern.
+	 *
+	 * @param array<string,mixed> $block The block to populate.
+	 * @return array<string,mixed> The populated block.
+	 */
+	private static function populate_pattern_inner_blocks( array $block ): array {
+		// Bail if not WP 6.6 or later.
+		if ( ! function_exists( 'resolve_pattern_blocks' ) ) {
+			return $block;
+		}
+
+		if ( 'core/pattern' !== $block['blockName'] || ! isset( $block['attrs']['slug'] ) ) {
+			return $block;
+		}
+
+		$resolved_patterns = resolve_pattern_blocks( [ $block ] );
+
+		if ( empty( $resolved_patterns ) ) {
+			return $block;
+		}
+
+		$block['innerBlocks'] = $resolved_patterns;
+		return $block;
 	}
 
 	/**


### PR DESCRIPTION
## What you did in this PR ?
Back ported functionality to resolve and populate innerBlocks for `core/template-part` blocks and included a test to ensure template part inner blocks are resolved correctly.

## Why is it necessary ?
This is necessary so as to support nested blocks within template-part blocks.

## How ?

- Backported `populate_template_part_inner_blocks` to retrieve and parse template part content using `get_block_templates`.
- Added a integration test to validate the correct resolution of template part blocks in both flat and nested contexts.



### Tasks :

- [x] Backport populate_template_part_inner_blocks()
- [x] Add Codeception unit test