### PR TITLE
Feat : backporting `populate pattern inner blocks`

### DIFF
--- a/.changeset/tiny-news-warn.md
+++ b/.changeset/tiny-news-warn.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving Block Patterns

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -151,6 +151,8 @@ final class ContentBlocksResolver {
 
 		$block = self::populate_reusable_blocks( $block );
 
+		$block = self::populate_pattern_inner_blocks( $block );
+
 		// Prepare innerBlocks.
 		if ( ! empty( $block['innerBlocks'] ) ) {
 			$block['innerBlocks'] = self::handle_do_blocks( $block['innerBlocks'] );
@@ -206,6 +208,32 @@ final class ContentBlocksResolver {
 		}
 
 		return array_merge( ...$parsed_blocks );
+	}
+
+	/**
+	 * Populates the pattern innerBlocks with the blocks from the pattern.
+	 *
+	 * @param array<string,mixed> $block The block to populate.
+	 * @return array<string,mixed> The populated block.
+	 */
+	private static function populate_pattern_inner_blocks( array $block ): array {
+		// Bail if not WP 6.6 or later.
+		if ( ! function_exists( 'resolve_pattern_blocks' ) ) {
+			return $block;
+		}
+
+		if ( 'core/pattern' !== $block['blockName'] || ! isset( $block['attrs']['slug'] ) ) {
+			return $block;
+		}
+
+		$resolved_patterns = resolve_pattern_blocks( [ $block ] );
+
+		if ( empty( $resolved_patterns ) ) {
+			return $block;
+		}
+
+		$block['innerBlocks'] = $resolved_patterns;
+		return $block;
 	}
 
 	/**


### PR DESCRIPTION
## What you did in this PR ?
Back ported functionality to resolve and populate innerBlocks for `core/pattern` blocks and included a test to verify pattern inner block resolution.

## Why is it necessary ?
To ensure `core/pattern` blocks can correctly resolve and include their nested blocks.

## How ?
- Back ported `populate_pattern_inner_blocks` to resolve pattern blocks using `resolve_pattern_blocks`.
- Added an integration test to validate block resolution for patterns in both flat and nested contexts.
- Registered and unregistered a test block pattern to simulate the functionality.

### Tasks :
- [x] Backport `populate pattern inner blocks`.
- [x] Add codeception unit test