### PR TITLE
feat : backport populate_post_content_inner_blocks

### DIFF
--- a/.changeset/itchy-mugs-sniff.md
+++ b/.changeset/itchy-mugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving PostContent blocks

--- a/.changeset/silver-cups-explode.md
+++ b/.changeset/silver-cups-explode.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving Template Part blocks

--- a/.changeset/tiny-news-warn.md
+++ b/.changeset/tiny-news-warn.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving Block Patterns

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -151,6 +151,8 @@ final class ContentBlocksResolver {
 
 		$block = self::populate_reusable_blocks( $block );
 
+		$block = self::populate_pattern_inner_blocks( $block );
+
 		// Prepare innerBlocks.
 		if ( ! empty( $block['innerBlocks'] ) ) {
 			$block['innerBlocks'] = self::handle_do_blocks( $block['innerBlocks'] );
@@ -206,6 +208,32 @@ final class ContentBlocksResolver {
 		}
 
 		return array_merge( ...$parsed_blocks );
+	}
+
+	/**
+	 * Populates the pattern innerBlocks with the blocks from the pattern.
+	 *
+	 * @param array<string,mixed> $block The block to populate.
+	 * @return array<string,mixed> The populated block.
+	 */
+	private static function populate_pattern_inner_blocks( array $block ): array {
+		// Bail if not WP 6.6 or later.
+		if ( ! function_exists( 'resolve_pattern_blocks' ) ) {
+			return $block;
+		}
+
+		if ( 'core/pattern' !== $block['blockName'] || ! isset( $block['attrs']['slug'] ) ) {
+			return $block;
+		}
+
+		$resolved_patterns = resolve_pattern_blocks( [ $block ] );
+
+		if ( empty( $resolved_patterns ) ) {
+			return $block;
+		}
+
+		$block['innerBlocks'] = $resolved_patterns;
+		return $block;
 	}
 
 	/**

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -149,8 +149,8 @@ final class ContentBlocksResolver {
 
 		// @todo apply more hydrations.
 		$block = self::populate_template_part_inner_blocks( $block );
+		$block = self::populate_post_content_inner_blocks( $block );
 		$block = self::populate_reusable_blocks( $block );
-
 		$block = self::populate_pattern_inner_blocks( $block );
 
 		// Prepare innerBlocks.
@@ -209,6 +209,35 @@ final class ContentBlocksResolver {
 		}
 
 		$block['innerBlocks'] = $template_blocks;
+
+		return $block;
+	}
+
+	/**
+	 * Populates the innerBlocks of a core/post-content block with the blocks from the post content.
+	 *
+	 * @param array<string,mixed> $block The block to populate.
+	 *
+	 * @return array<string,mixed> The populated block.
+	 */
+	private static function populate_post_content_inner_blocks( array $block ): array {
+		if ( 'core/post-content' !== $block['blockName'] ) {
+			return $block;
+		}
+
+		$post = get_post();
+
+		if ( ! $post ) {
+			return $block;
+		}
+
+		$parsed_blocks = ! empty( $post->post_content ) ? self::parse_blocks( $post->post_content ) : null;
+
+		if ( empty( $parsed_blocks ) ) {
+			return $block;
+		}
+
+		$block['innerBlocks'] = $parsed_blocks;
 
 		return $block;
 	}


### PR DESCRIPTION
## What you did in this PR ?
Back ported functionality to populate innerBlocks of the `core/post-content` block with the parsed blocks.

## Why is it necessary ?
To ensure `core/post-content` block dynamically includes blocks from the post content.

## How ?
- Back ported `populate_post_content_inner_blocks` to fetch the post's content, parse it into blocks, and assign it to the innerBlocks property if available.

### Tasks :
- [x] Backport `populate_post_content_inner_blocks`.
- [ ] Add Codeception unit test.